### PR TITLE
Bump Go to 1.4.2 and rework PKGBUILD file

### DIFF
--- a/community/go/PKGBUILD
+++ b/community/go/PKGBUILD
@@ -23,22 +23,15 @@ options=('!strip')
 install="$pkgname.install"
 backup=('usr/lib/go/bin')
 
-if [ "$CARCH" == 'x86_64' ]; then
-  source=("https://storage.googleapis.com/golang/${pkgname}${pkgver}.freebsd-amd64.tar.gz"
-          "$pkgname.sh")
-  sha256sums=('50adbcbb5f44c3559c1b1f8edd8a1bdb2075d8ff58cb9ede6a38afa72e6bdbc1'
-            'a03db71d323ed2794123bb31b5c8ad5febd551c490b5c0b341052c8e5f0ba892')
-
-else
-  source=("http://go.googlecode.com/files/${pkgname}$pkgver.freebsd-386.tar.gz"
-          "$pkgname.sh")
-  sha256sums=('d1da02ddcceee4f6b4060188f16c77ec8c9aec3953214adecc43df32b0b93347'
-              'a03db71d323ed2794123bb31b5c8ad5febd551c490b5c0b341052c8e5f0ba892')
-fi
+source=("https://storage.googleapis.com/golang/${pkgname}${pkgver}.src.tar.gz")
+sha256sums=('66665005fac35ba832ff334977e658f961109d89a7a2358ae7707be0efb16fca')
 
 build() {
   cd "$srcdir/$pkgname/src"
 
+  export GOROOT="${srcdir}/${pkgname}"
+  export GOBIN="${GOROOT}/bin"
+  export GOPATH="${srcdir}/"
   export GOROOT_FINAL=/usr/lib/go
 
   bash make.bash
@@ -48,37 +41,49 @@ build() {
   export GO386=387
 
   # Crosscompilation for various platforms (including linux)
-  for os in freebsd; do # darwin freebsd windows; do
+  for os in freebsd; do # darwin linux windows; do
     for arch in amd64 386; do
       export GOOS="$os"
       export GOARCH="$arch"
       bash make.bash --no-clean
     done
   done
+
+  $GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc
+  $GOROOT/bin/go build -o $srcdir/godoc golang.org/x/tools/cmd/godoc
+  for tool in vet cover callgraph; do
+    $GOROOT/bin/go get -d golang.org/x/tools/cmd/${tool}
+    $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${tool} golang.org/x/tools/cmd/${tool}
+  done
 }
 
 check() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname"
+
+  #export GO386=387
 
   export GOOS=freebsd
-  if [ "$CARCH" == 'x86_64' ]; then
+  if [ "$CARCH" == 'x86_64'  ]; then
     export GOARCH=amd64
-  elif [ "$CARCH" == 'i686' ]; then
+  elif [ "$CARCH" == 'i686'  ]; then
     export GOARCH=386
   fi
 
   export GOROOT="$srcdir/$pkgname"
+  export GOBIN="$GOROOT/bin"
   export PATH="$srcdir/$pkgname/bin:$PATH"
 
-  # TestSimpleMulticastListener will fail in standard chroot.
+  # TestSimpleMulticastListener will fail in standard chroot
   cd src && bash run.bash --no-rebuild || true
 }
 
 package() {
-  cd "${srcdir}/$pkgname"
+  cd "${srcdir}/${pkgname}"
 
   export GOROOT="$srcdir/$pkgname"
   export GOBIN="$GOROOT/bin"
+
+  install -Dm755 "$srcdir/godoc" "$pkgdir/usr/bin/godoc"
 
   install -dm755 "$pkgdir/usr/bin"
 
@@ -89,7 +94,7 @@ package() {
   mkdir -p \
     "$pkgdir/"{etc/profile.d,usr/{share/go,lib/go,lib/go/src,lib/go/site/src}}
 
-  cp -r doc misc "$pkgdir/usr/share/go/"
+  cp -r doc misc -t "$pkgdir/usr/share/go/"
   ln -s /usr/share/go/doc "$pkgdir/usr/lib/go/doc"
   cp -r bin "$pkgdir/usr"
   cp -r pkg "$pkgdir/usr/lib/go"

--- a/community/go/PKGBUILD
+++ b/community/go/PKGBUILD
@@ -27,7 +27,7 @@ source=("https://storage.googleapis.com/golang/${pkgname}${pkgver}.src.tar.gz")
 sha256sums=('66665005fac35ba832ff334977e658f961109d89a7a2358ae7707be0efb16fca')
 
 build() {
-  cd "$srcdir/$pkgname/src"
+  cd "${srcdir}/${pkgname}/src"
 
   export GOROOT="${srcdir}/${pkgname}"
   export GOBIN="${GOROOT}/bin"
@@ -43,35 +43,35 @@ build() {
   # Crosscompilation for various platforms (including linux)
   for os in freebsd; do # darwin linux windows; do
     for arch in amd64 386; do
-      export GOOS="$os"
-      export GOARCH="$arch"
+      export GOOS="${os}"
+      export GOARCH="${arch}"
       bash make.bash --no-clean
     done
   done
 
-  $GOROOT/bin/go get -d golang.org/x/tools/cmd/godoc
-  $GOROOT/bin/go build -o $srcdir/godoc golang.org/x/tools/cmd/godoc
+  ${GOROOT}/bin/go get -d golang.org/x/tools/cmd/godoc
+  ${GOROOT}/bin/go build -o ${srcdir}/godoc golang.org/x/tools/cmd/godoc
   for tool in vet cover callgraph; do
-    $GOROOT/bin/go get -d golang.org/x/tools/cmd/${tool}
-    $GOROOT/bin/go build -o $GOROOT/pkg/tool/${GOOS}_${GOARCH}/${tool} golang.org/x/tools/cmd/${tool}
+    ${GOROOT}/bin/go get -d golang.org/x/tools/cmd/${tool}
+    ${GOROOT}/bin/go build -o ${GOROOT}/pkg/tool/${GOOS}_${GOARCH}/${tool} golang.org/x/tools/cmd/${tool}
   done
 }
 
 check() {
-  cd "$pkgname"
+  cd "${pkgname}"
 
   #export GO386=387
 
   export GOOS=freebsd
-  if [ "$CARCH" == 'x86_64'  ]; then
+  if [ "${CARCH}" == 'x86_64'  ]; then
     export GOARCH=amd64
-  elif [ "$CARCH" == 'i686'  ]; then
+  elif [ "${CARCH}" == 'i686'  ]; then
     export GOARCH=386
   fi
 
-  export GOROOT="$srcdir/$pkgname"
-  export GOBIN="$GOROOT/bin"
-  export PATH="$srcdir/$pkgname/bin:$PATH"
+  export GOROOT="${srcdir}/${pkgname}"
+  export GOBIN="${GOROOT}/bin"
+  export PATH="${srcdir}/${pkgname}/bin:${PATH}"
 
   # TestSimpleMulticastListener will fail in standard chroot
   cd src && bash run.bash --no-rebuild || true
@@ -80,60 +80,59 @@ check() {
 package() {
   cd "${srcdir}/${pkgname}"
 
-  export GOROOT="$srcdir/$pkgname"
-  export GOBIN="$GOROOT/bin"
+  export GOROOT="${srcdir}/${pkgname}"
+  export GOBIN="${GOROOT}/bin"
 
-  install -Dm755 "$srcdir/godoc" "$pkgdir/usr/bin/godoc"
+  install -dm755 "${pkgdir}/usr/bin"
 
-  install -dm755 "$pkgdir/usr/bin"
-
-  install -dm755 "$pkgdir/usr/share/licenses/go"
+  install -dm755 "${pkgdir}/usr/share/licenses/go"
   install -m644 LICENSE \
-    "$pkgdir/usr/share/licenses/go/LICENSE"
+    "${pkgdir}/usr/share/licenses/go/LICENSE"
 
   mkdir -p \
-    "$pkgdir/"{etc/profile.d,usr/{share/go,lib/go,lib/go/src,lib/go/site/src}}
+    "${pkgdir}/"{etc/profile.d,usr/{share/go,lib/go,lib/go/src,lib/go/site/src}}
 
-  cp -r doc misc -t "$pkgdir/usr/share/go/"
-  ln -s /usr/share/go/doc "$pkgdir/usr/lib/go/doc"
-  cp -r bin "$pkgdir/usr"
-  cp -r pkg "$pkgdir/usr/lib/go"
-  cp -r "$GOROOT/src" "$pkgdir/usr/lib/go/"
-  cp -r "$GOROOT/src/cmd" "$pkgdir/usr/lib/go/src/cmd"
-  cp -r "$GOROOT/src/lib9" "$pkgdir/usr/lib/go/src/"
-  cp -r "$GOROOT/lib" "$pkgdir/usr/lib/go/"
-  cp -r "$GOROOT/include" "$pkgdir/usr/lib/go/"
+  cp -r "${srcdir}/godoc" "${pkgdir}/usr/bin/godoc"
+  cp -r doc misc "${pkgdir}/usr/share/go/"
+  ln -s /usr/share/go/doc "${pkgdir}/usr/lib/go/doc"
+  cp -r bin "${pkgdir}/usr"
+  cp -r pkg "${pkgdir}/usr/lib/go"
+  cp -r "${GOROOT}/src" "${pkgdir}/usr/lib/go/"
+  cp -r "${GOROOT}/src/cmd" "${pkgdir}/usr/lib/go/src/cmd"
+  cp -r "${GOROOT}/src/lib9" "${pkgdir}/usr/lib/go/src/"
+  cp -r "${GOROOT}/lib" "${pkgdir}/usr/lib/go/"
+  cp -r "${GOROOT}/include" "${pkgdir}/usr/lib/go/"
 
-  install -m644 src/Make.* "$pkgdir/usr/lib/go/src"
+  install -m644 src/Make.* "${pkgdir}/usr/lib/go/src"
 
   # Remove object files from target src dir
-  find "$pkgdir/usr/lib/go/src/" -type f -name '*.[ao]' -delete
+  find "${pkgdir}/usr/lib/go/src/" -type f -name '*.[ao]' -delete
 
   # Fix for FS#32813
-  find "$pkgdir" -type f -name sql.go -exec chmod -x {} \;
+  find "${pkgdir}" -type f -name sql.go -exec chmod -x {} \;
 
   # Remove all executable source files
-  find "$pkgdir/usr/lib/go/src" -type f -perm '++x' -delete
+  find "${pkgdir}/usr/lib/go/src" -type f -perm '++x' -delete
 
   # This is to make go get code.google.com/p/go-tour/gotour and
   # then running the gotour executable work out of the box.
-  ln -sf /usr/bin "$pkgdir/usr/lib/go/bin"
+  ln -sf /usr/bin "${pkgdir}/usr/lib/go/bin"
 
   # For FS#42660 / FS#42661 / gox
-  install -dm755 "$pkgdir/usr/lib/go/src"
-  install -m755 src/make.bash "$pkgdir/usr/lib/go/src/make.bash"
-  install -m755 src/run.bash "$pkgdir/usr/lib/go/src/run.bash"
-  cp -r misc/ "$pkgdir/usr/lib/go/"
+  install -dm755 "${pkgdir}/usr/lib/go/src"
+  install -m755 src/make.bash "${pkgdir}/usr/lib/go/src/make.bash"
+  install -m755 src/run.bash "${pkgdir}/usr/lib/go/src/run.bash"
+  cp -r misc/ "${pkgdir}/usr/lib/go/"
 
   # For godoc
-  install -m644 favicon.ico "$pkgdir/usr/lib/go/favicon.ico"
+  install -Dm755 "${srcdir}/godoc" "${pkgdir}/usr/bin/godoc"
+  install -m644 favicon.ico "${pkgdir}/usr/lib/go/favicon.ico"
 
-  rm -f "$pkgdir/usr/share/go/doc/articles/wiki/get.bin"
+  rm -f "${pkgdir}/usr/share/go/doc/articles/wiki/get.bin"
 
-  install -m644 VERSION "$pkgdir/usr/lib/go/VERSION"
+  install -m644 VERSION "${pkgdir}/usr/lib/go/VERSION"
 
-  find "$pkgdir/usr/"{lib/go/pkg,bin} -type f -exec touch '{}' +
-
+  find "${pkgdir}/usr/"{lib/go/pkg,bin} -type f -exec touch '{}' +
 }
 
 # vim:set ts=2 sw=2 et:

--- a/community/go/PKGBUILD
+++ b/community/go/PKGBUILD
@@ -11,7 +11,7 @@
 # TODO: Create split packages for the crosscompilation versions? (maybe)
 
 pkgname=go
-pkgver=1.4.1
+pkgver=1.4.2
 pkgrel=1
 pkgdesc='Compiler and tools for the Go programming language from Google'
 arch=('x86_64' 'i686')
@@ -24,7 +24,7 @@ install="$pkgname.install"
 backup=('usr/lib/go/bin')
 
 source=("https://storage.googleapis.com/golang/${pkgname}${pkgver}.src.tar.gz")
-sha256sums=('66665005fac35ba832ff334977e658f961109d89a7a2358ae7707be0efb16fca')
+sha256sums=('299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b')
 
 build() {
   cd "${srcdir}/${pkgname}/src"


### PR DESCRIPTION
Rework the PKGBUILD file for Go so that it doesn't pull the pre-compiled version of the package just to turn around and rebuild everything.  Now it just pulls the source code package and builds that.  This reduces duplicated efforts and pulls the smaller tarball.

Also by switching to pulling the source package, this allows upgrading to version 1.4.2 which never got a FreeBSD build in upstream.